### PR TITLE
chore(wasm-utils): update version number

### DIFF
--- a/wasm-utils/Cargo.lock
+++ b/wasm-utils/Cargo.lock
@@ -602,7 +602,7 @@ checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
 
 [[package]]
 name = "wasm-utils"
-version = "0.1.0"
+version = "0.1.5"
 dependencies = [
  "js-sys",
  "statechannels-native-utils-common",

--- a/wasm-utils/Cargo.toml
+++ b/wasm-utils/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "wasm-utils"
-version = "0.1.0"
+version = "0.1.5"
 edition = "2018"
 license = "MIT"
-authors = ["Jannis Pohlmann <jannis@thegraph.com>"]
+authors = [
+    "Jannis Pohlmann <jannis@thegraph.com>",
+    "George Knee <george.knee@mesh.xyz>"
+    ]
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
 in Cargo.toml; this in turn means the gitignored npm module that is built using wasm-pack has the updated version number