### PR TITLE
add new GH action for git diff --exit-code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,17 @@ on:
     branches: [master]
 
 jobs:
+  check-git-clean:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+      - run: yarn bootstrap
+      - run: git diff --exit-code
+
   build-wasm:
     runs-on: ubuntu-latest
 
@@ -42,19 +53,3 @@ jobs:
       - run: yarn bootstrap
       - run: yarn test
       - run: yarn bench
-
-  check-git-clean:
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [12.x]
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
-      - run: yarn bootstrap
-      - run: git diff --exit-code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
       - run: yarn bootstrap
       - run: yarn test
       - run: yarn bench
+
   build-native:
     runs-on: ubuntu-latest
 
@@ -41,3 +42,19 @@ jobs:
       - run: yarn bootstrap
       - run: yarn test
       - run: yarn bench
+
+  check-git-clean:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: yarn bootstrap
+      - run: git diff --exit-code


### PR DESCRIPTION
prevents the`yarn.lock` becoming out of sync by forgetting to check it in. Similar to `--frozen-lockfile` flag (but superior IMO). 